### PR TITLE
Don't need access specifier for function

### DIFF
--- a/utility/src/main/java/com/android/utility/AlertDialogInterface.java
+++ b/utility/src/main/java/com/android/utility/AlertDialogInterface.java
@@ -5,6 +5,6 @@ package com.android.utility;
  */
 
 public interface AlertDialogInterface {
-    public void positiveButtonPressed();
-    public void negativeButtonPressed();
+    void positiveButtonPressed();
+    void negativeButtonPressed();
 }


### PR DESCRIPTION
If the interface has been declared public don't need to specify access specifier for functions